### PR TITLE
Image upload

### DIFF
--- a/pixie-led.py
+++ b/pixie-led.py
@@ -10,25 +10,25 @@ app = Flask(__name__)
 
 # prevent connection being reset during file upload ?
 # from : https://www.cocept.io/blog/development/flask-file-upload-connection-reset/
-from werkzeug.wsgi import LimitedStream
-class StreamConsumingMiddleware(object):
+# from werkzeug.wsgi import LimitedStream
+# class StreamConsumingMiddleware(object):
 
-    def __init__(self, app):
-        self.app = app
+#     def __init__(self, app):
+#         self.app = app
 
-    def __call__(self, environ, start_response):
-        stream = LimitedStream(environ['wsgi.input'],
-                               int(environ['CONTENT_LENGTH'] or 0))
-        environ['wsgi.input'] = stream
-        app_iter = self.app(environ, start_response)
-        try:
-            stream.exhaust()
-            for event in app_iter:
-                yield event
-        finally:
-            if hasattr(app_iter, 'close'):
-                app_iter.close()
-app.wsgi_app = StreamConsumingMiddleware(app.wsgi_app)
+#     def __call__(self, environ, start_response):
+#         stream = LimitedStream(environ['wsgi.input'],
+#                                int(environ['CONTENT_LENGTH'] or 0))
+#         environ['wsgi.input'] = stream
+#         app_iter = self.app(environ, start_response)
+#         try:
+#             stream.exhaust()
+#             for event in app_iter:
+#                 yield event
+#         finally:
+#             if hasattr(app_iter, 'close'):
+#                 app_iter.close()
+# app.wsgi_app = StreamConsumingMiddleware(app.wsgi_app)
 
 
 # Configuration for the matrix

--- a/pixie-led.py
+++ b/pixie-led.py
@@ -10,7 +10,7 @@ from PIL import Image
 app = Flask(__name__)
 app.config['MAX_CONTENT_LENGTH'] = 10 * 1024 * 1024 # max 10MB
 app.config['UPLOAD_EXTENSIONS'] = ['.jpg', '.png', '.gif']
-app.config['UPLOAD_PATH'] = 'cache'
+app.config['UPLOAD_PATH'] = '/app/cache'
 
 
 # prevent connection being reset during file upload ?

--- a/pixie-led.py
+++ b/pixie-led.py
@@ -10,7 +10,7 @@ from PIL import Image
 app = Flask(__name__)
 app.config['MAX_CONTENT_LENGTH'] = 10 * 1024 * 1024 # max 10MB
 app.config['UPLOAD_EXTENSIONS'] = ['.jpg', '.png', '.gif']
-app.config['UPLOAD_PATH'] = ''
+app.config['UPLOAD_PATH'] = '/home/ubuntu/pixie/cache'
 
 
 # prevent connection being reset during file upload ?

--- a/pixie-led.py
+++ b/pixie-led.py
@@ -45,6 +45,7 @@ options.parallel = 1
 options.hardware_mapping = 'adafruit-hat'
 options.disable_hardware_pulsing = True
 options.gpio_slowdown = 3
+options.drop_privileges = False
 
 matrix = RGBMatrix(options = options)
 offscreen_canvas = matrix.CreateFrameCanvas()

--- a/pixie-led.py
+++ b/pixie-led.py
@@ -89,12 +89,11 @@ def upload_image():
         file_ext = os.path.splitext(filename)[1]
         if file_ext not in app.config['UPLOAD_EXTENSIONS']:
             abort(400)
-        # with open(filename, 'wb') as f:
-        #     f.write(request.files.data)
         uploaded_file.save(os.path.join(app.config['UPLOAD_PATH'], filename))
-        uploaded_file.close()
-    return jsonify({"succes": True})
-    # return redirect(url_for('index'))
+        uploaded_file.close() # Permission denied if you don't close the file...
+    # return jsonify({"succes": True})
+    return redirect('/pixie/api/v1.0/show_image?filename=cache/'+filename)
+
 
 if __name__ == '__main__':
     app.run(debug=True)

--- a/pixie-led.py
+++ b/pixie-led.py
@@ -10,7 +10,7 @@ from PIL import Image
 app = Flask(__name__)
 app.config['MAX_CONTENT_LENGTH'] = 10 * 1024 * 1024 # max 10MB
 app.config['UPLOAD_EXTENSIONS'] = ['.jpg', '.png', '.gif']
-app.config['UPLOAD_PATH'] = '/app/cache'
+app.config['UPLOAD_PATH'] = '../cache'
 
 
 # prevent connection being reset during file upload ?

--- a/pixie-led.py
+++ b/pixie-led.py
@@ -92,7 +92,7 @@ def upload_image():
         with open('test_data', 'wb') as f:
             f.write(request.data)
         # uploaded_file.save(os.path.join(app.config['UPLOAD_PATH'], filename))
-    return jsonify(request.files)
+    return jsonify({"succes": True})
     # return redirect(url_for('index'))
 
 if __name__ == '__main__':

--- a/pixie-led.py
+++ b/pixie-led.py
@@ -1,7 +1,7 @@
 #!flask/bin/python
 from flask import Flask, jsonify, request, render_template, redirect, url_for
 from werkzeug.utils import secure_filename
-import sys, time
+import sys, time, os
 
 from rgbmatrix import RGBMatrix, RGBMatrixOptions
 from PIL import Image

--- a/pixie-led.py
+++ b/pixie-led.py
@@ -10,7 +10,7 @@ from PIL import Image
 app = Flask(__name__)
 app.config['MAX_CONTENT_LENGTH'] = 10 * 1024 * 1024 # max 10MB
 app.config['UPLOAD_EXTENSIONS'] = ['.jpg', '.png', '.gif']
-app.config['UPLOAD_PATH'] = 'cache'
+app.config['UPLOAD_PATH'] = './cache'
 
 
 # prevent connection being reset during file upload ?

--- a/pixie-led.py
+++ b/pixie-led.py
@@ -89,7 +89,7 @@ def upload_image():
         file_ext = os.path.splitext(filename)[1]
         if file_ext not in app.config['UPLOAD_EXTENSIONS']:
             abort(400)
-        with open('test.json', 'w') as f:
+        with open('test_data', 'wb') as f:
             f.write(request.data)
         # uploaded_file.save(os.path.join(app.config['UPLOAD_PATH'], filename))
     return jsonify(request.files)

--- a/pixie-led.py
+++ b/pixie-led.py
@@ -43,6 +43,9 @@ options.cols = 32
 options.chain_length = 1
 options.parallel = 1
 options.hardware_mapping = 'adafruit-hat'
+options.disable_hardware_pulsing = True
+options.gpio_slowdown = 2
+options.drop_privileges = False
 
 matrix = RGBMatrix(options = options)
 offscreen_canvas = matrix.CreateFrameCanvas()

--- a/pixie-led.py
+++ b/pixie-led.py
@@ -1,5 +1,5 @@
 #!flask/bin/python
-from flask import Flask, jsonify, request
+from flask import Flask, jsonify, request, render_template, redirect, url_for
 import sys, time
 from rgbmatrix import RGBMatrix, RGBMatrixOptions
 from PIL import Image
@@ -43,6 +43,18 @@ def show_image():
     offscreen_canvas = matrix.SwapOnVSync(offscreen_canvas)
     return jsonify({'success': True, 'image_file': image_file})
 
+
+@app.route('/pixie/upload', methods=['GET'])
+def index():
+    return render_template('upload.html')
+
+
+@app.route('/pixie/api/v1.0/upload_image', methods=['POST'])
+def upload_image()
+    uploaded_file = request.files['file']
+    if uploaded_file.filename != '':
+        uploaded_file.save(uploaded_file.filename)
+    return redirect(url_for('index'))
 
 if __name__ == '__main__':
     app.run(debug=True)

--- a/pixie-led.py
+++ b/pixie-led.py
@@ -44,7 +44,7 @@ def show_image():
     return jsonify({'success': True, 'image_file': image_file})
 
 
-@app.route('/pixie/upload', methods=['GET'])
+@app.route('/pixie/upload', methods=['GET', 'POST'])
 def index():
     return render_template('upload.html')
 

--- a/pixie-led.py
+++ b/pixie-led.py
@@ -7,6 +7,30 @@ from PIL import Image
 
 app = Flask(__name__)
 
+
+# prevent connection being reset during file upload ?
+# from : https://www.cocept.io/blog/development/flask-file-upload-connection-reset/
+from werkzeug.wsgi import LimitedStream
+class StreamConsumingMiddleware(object):
+
+    def __init__(self, app):
+        self.app = app
+
+    def __call__(self, environ, start_response):
+        stream = LimitedStream(environ['wsgi.input'],
+                               int(environ['CONTENT_LENGTH'] or 0))
+        environ['wsgi.input'] = stream
+        app_iter = self.app(environ, start_response)
+        try:
+            stream.exhaust()
+            for event in app_iter:
+                yield event
+        finally:
+            if hasattr(app_iter, 'close'):
+                app_iter.close()
+app.wsgi_app = StreamConsumingMiddleware(app.wsgi_app)
+
+
 # Configuration for the matrix
 options = RGBMatrixOptions()
 options.rows = 32

--- a/pixie-led.py
+++ b/pixie-led.py
@@ -10,7 +10,7 @@ from PIL import Image
 app = Flask(__name__)
 app.config['MAX_CONTENT_LENGTH'] = 10 * 1024 * 1024 # max 10MB
 app.config['UPLOAD_EXTENSIONS'] = ['.jpg', '.png', '.gif']
-app.config['UPLOAD_PATH'] = '../cache'
+app.config['UPLOAD_PATH'] = ''
 
 
 # prevent connection being reset during file upload ?

--- a/pixie-led.py
+++ b/pixie-led.py
@@ -54,7 +54,8 @@ def upload_image():
     uploaded_file = request.files['file']
     if uploaded_file.filename != '':
         uploaded_file.save(uploaded_file.filename)
-    return redirect(url_for('index'))
+    return jsonify(request.files)
+    # return redirect(url_for('index'))
 
 if __name__ == '__main__':
     app.run(debug=True)

--- a/pixie-led.py
+++ b/pixie-led.py
@@ -89,7 +89,9 @@ def upload_image():
         file_ext = os.path.splitext(filename)[1]
         if file_ext not in app.config['UPLOAD_EXTENSIONS']:
             abort(400)
-        uploaded_file.save(os.path.join(app.config['UPLOAD_PATH'], filename))
+        with open('test.json', 'w') as f:
+            f.write(request.data)
+        # uploaded_file.save(os.path.join(app.config['UPLOAD_PATH'], filename))
     return jsonify(request.files)
     # return redirect(url_for('index'))
 

--- a/pixie-led.py
+++ b/pixie-led.py
@@ -50,7 +50,7 @@ def index():
 
 
 @app.route('/pixie/api/v1.0/upload_image', methods=['POST'])
-def upload_image()
+def upload_image():
     uploaded_file = request.files['file']
     if uploaded_file.filename != '':
         uploaded_file.save(uploaded_file.filename)

--- a/pixie-led.py
+++ b/pixie-led.py
@@ -10,7 +10,7 @@ from PIL import Image
 app = Flask(__name__)
 app.config['MAX_CONTENT_LENGTH'] = 10 * 1024 * 1024 # max 10MB
 app.config['UPLOAD_EXTENSIONS'] = ['.jpg', '.png', '.gif']
-app.config['UPLOAD_PATH'] = './cache'
+app.config['UPLOAD_PATH'] = 'cache'
 
 
 # prevent connection being reset during file upload ?

--- a/pixie-led.py
+++ b/pixie-led.py
@@ -1,3 +1,4 @@
+#!flask/bin/python
 from flask import Flask, jsonify, request, render_template, redirect, url_for
 from werkzeug.utils import secure_filename
 import sys, time, os

--- a/pixie-led.py
+++ b/pixie-led.py
@@ -89,9 +89,10 @@ def upload_image():
         file_ext = os.path.splitext(filename)[1]
         if file_ext not in app.config['UPLOAD_EXTENSIONS']:
             abort(400)
-        with open('test_data', 'wb') as f:
-            f.write(request.data)
-        # uploaded_file.save(os.path.join(app.config['UPLOAD_PATH'], filename))
+        # with open(filename, 'wb') as f:
+        #     f.write(request.files.data)
+        uploaded_file.save(os.path.join(app.config['UPLOAD_PATH'], filename))
+        uploaded_file.close()
     return jsonify({"succes": True})
     # return redirect(url_for('index'))
 

--- a/pixie-led.py
+++ b/pixie-led.py
@@ -1,4 +1,3 @@
-#!flask/bin/python
 from flask import Flask, jsonify, request, render_template, redirect, url_for
 from werkzeug.utils import secure_filename
 import sys, time, os

--- a/pixie-led.py
+++ b/pixie-led.py
@@ -44,8 +44,7 @@ options.chain_length = 1
 options.parallel = 1
 options.hardware_mapping = 'adafruit-hat'
 options.disable_hardware_pulsing = True
-options.gpio_slowdown = 2
-options.drop_privileges = False
+options.gpio_slowdown = 3
 
 matrix = RGBMatrix(options = options)
 offscreen_canvas = matrix.CreateFrameCanvas()

--- a/run_server.sh
+++ b/run_server.sh
@@ -1,4 +1,4 @@
 export FLASK_APP=pixie-led.py
 export FLASK_ENV=development
-flask run --host=0.0.0.0
+flask run --host=0.0.0.0 --port=80
  

--- a/run_server.sh
+++ b/run_server.sh
@@ -1,3 +1,4 @@
 export FLASK_APP=pixie-led.py
+export FLASK_ENV=development
 flask run --host=0.0.0.0
  

--- a/templates/upload.html
+++ b/templates/upload.html
@@ -5,7 +5,7 @@
   </head>
   <body>
     <h1>File Upload</h1>
-    <form method="POST" action="" enctype="multipart/form-data">
+    <form method="POST" action="{{ url_for('upload_image') }}" enctype="multipart/form-data">
       <p><input type="file" name="file" accept="image/*"></p>
       <p><input type="submit" value="Submit"></p>
     </form>

--- a/templates/upload.html
+++ b/templates/upload.html
@@ -1,0 +1,13 @@
+<!doctype html>
+<html>
+  <head>
+    <title>File Upload</title>
+  </head>
+  <body>
+    <h1>File Upload</h1>
+    <form method="POST" action="" enctype="multipart/form-data">
+      <p><input type="file" name="file" accept="image/*"></p>
+      <p><input type="submit" value="Submit"></p>
+    </form>
+  </body>
+</html>


### PR DESCRIPTION
Included image upload via basic flask uploading.

There are two requirements:
`options.drop_privileges = False`
and after:
`uploaded_file.save(os.path.join(app.config['UPLOAD_PATH'], filename))`
you seem to need to call
`uploaded_file.close()`
in case of an `Errno 13`.