### PR TITLE
Static routes

### DIFF
--- a/pixie_led.py
+++ b/pixie_led.py
@@ -1,5 +1,5 @@
 #!flask/bin/python
-from flask import Flask, jsonify, request, render_template, redirect, url_for, abort
+from flask import Flask, jsonify, request, render_template, redirect, url_for, abort, send_from_directory
 from werkzeug.utils import secure_filename
 import sys
 import time
@@ -172,6 +172,16 @@ def show_queue():
     # return render_template('queue.html')
 
 
+# Static routes (Flask.send_from_directory)
+@app.route('/pixie/img/<path>/<filename>', methods=['GET'])
+def serve_image(path, filename):
+    if path in app.config['IMAGE_FILE_DIRS']:
+        return send_from_directory(path, filename) # need secure_filename?
+        # os.path.join(path, secure_filename(filename))
+    else:
+        abort(403)
+
+
 # Task functions
 def fake_task(n):
     print(f"Task started. Delaying {n} seconds")
@@ -180,7 +190,8 @@ def fake_task(n):
     return n
 
 
-def panel_gif(filename, loop=10, delay=0.2):
+# Panel display functions
+def panel_gif(filename, loop=2, delay=0.05):
     # os.system("sudo /home/ubuntu/rpi-rgb-led-matrix/utils/led-image-viewer /home/ubuntu/pixie/cache/temp3.gif -t 5")
     global matrix, offscreen_canvas
     image = Image.open(filename)

--- a/pixie_led.py
+++ b/pixie_led.py
@@ -67,8 +67,8 @@ def enqueue_gif():
 @app.route('/pixie/api/v1.0/show_gif', methods=['GET'])
 def show_gif():
     filename = request.args.get('filename', './img/blank.png')
-    loop = int(request.args.get('loop', '10'))
-    delay = float(request.args.get('delay', '0.2'))
+    loop = int(request.args.get('loop', '2'))
+    delay = float(request.args.get('delay', '0.05'))
     panel_gif(filename, loop=loop, delay=delay)
     return jsonify({'success': True, 'image_file': filename})
 
@@ -191,7 +191,7 @@ def fake_task(n):
 
 
 # Panel display functions
-def panel_gif(filename, loop=2, delay=0.05):
+def panel_gif(filename, loop=1, delay=0.1):
     # os.system("sudo /home/ubuntu/rpi-rgb-led-matrix/utils/led-image-viewer /home/ubuntu/pixie/cache/temp3.gif -t 5")
     global matrix, offscreen_canvas
     image = Image.open(filename)

--- a/pixie_led.py
+++ b/pixie_led.py
@@ -11,6 +11,35 @@ import rq_dashboard
 from rgbmatrix import RGBMatrix, RGBMatrixOptions
 from PIL import Image
 
+# TODO: Refactor
+# Move redis to seperate file.
+# Split preparation and cached files (for display)
+# Seperate panel operations to a seperate package
+# Don't hardcode config -> load from startup script with ENV
+# Implement modes (with admin override)
+#   GIFBoard - Soundboard style gif collection
+#   Designer - Utility interface for creating animations. Mostly client side.
+#     Crop
+#     Timeline
+#     Touchup
+#     Messages? (possible on secondary pixel array)
+#   PixelBoard - Websocket pixel MSPaint
+# Utility
+#   Multifile upload & drag-n-drop
+#   File management
+# User management
+#   User login
+#   Admin interface
+#   User execution permissions
+# Clean up API
+# Clean up basic templates
+#   Navigation
+#   CSS
+# Refactor to multiple files
+# Get resources
+#   Shining force sprite sheets?
+#   Remove testing data
+
 
 # Config for Flask
 app = Flask(__name__)

--- a/templates/list.html
+++ b/templates/list.html
@@ -10,7 +10,7 @@
       {% for file in files %}
       <li>
         {{ file.filename }}
-        <img src="./pixie/img/{{file.filename}}" />
+        <img src="./img/{{file.filename}}" />
         <a
           onclick="showImage('./api/v1.0/show_image?filename={{file.filename}}')"
         >

--- a/templates/list.html
+++ b/templates/list.html
@@ -10,7 +10,7 @@
       {% for file in files %}
       <li>
         {{ file.filename }}
-        <img src="./img/{{file.filename}}" />
+        <img src="./img/{{file.filename}}" height="32" />
         <a
           onclick="showImage('./api/v1.0/show_image?filename={{file.filename}}')"
         >

--- a/templates/list.html
+++ b/templates/list.html
@@ -14,13 +14,13 @@
         <a
           onclick="showImage('./api/v1.0/show_image?filename={{file.filename}}')"
         >
-          [ showImage() ]
+          [img]
         </a>
         {% if file.extension == ".gif" %}
         <a
           onclick="showImage('./api/v1.0/show_gif?filename={{file.filename}}')"
         >
-          [ showGif() ]
+          [ani]
         </a>
         {% endif %}
       </li>

--- a/templates/list.html
+++ b/templates/list.html
@@ -1,4 +1,4 @@
-<!doctype html>
+<!DOCTYPE html>
 <html>
   <head>
     <title>Files</title>
@@ -7,28 +7,33 @@
     <h1>Uploaded Files</h1>
 
     <ol>
-      {% for file in files %} 
-        <li>
-          {{ file.filename }}
-            <a class="" onclick="showImage('./api/v1.0/show_image?filename={{file.filename}}')">
-              [ showImage() ]
-            </a>
-          {% if file.extension == ".gif" %}
-            <a class="" onclick="showImage('./api/v1.0/show_gif?filename={{file.filename}}')">
-              [ showGif() ]
-            </a>
-          {% endif %}
-        </li>
+      {% for file in files %}
+      <li>
+        {{ file.filename }}
+        <img src="./pixie/img/{{file.filename}}" />
+        <a
+          onclick="showImage('./api/v1.0/show_image?filename={{file.filename}}')"
+        >
+          [ showImage() ]
+        </a>
+        {% if file.extension == ".gif" %}
+        <a
+          onclick="showImage('./api/v1.0/show_gif?filename={{file.filename}}')"
+        >
+          [ showGif() ]
+        </a>
+        {% endif %}
+      </li>
       {% endfor %}
-    </ol> 
+    </ol>
 
     <script>
       function showImage(uri) {
         var req = new XMLHttpRequest();
-        req.addEventListener('load', console.log(this.responseText) );
-        req.open('GET', uri);
+        req.addEventListener("load", console.log(this.responseText));
+        req.open("GET", uri);
         req.send();
-      };
+      }
     </script>
   </body>
 </html>


### PR DESCRIPTION
`list` rout now returns some more readable options and a preview
`pixie_led.py` contains a TODO (TODO: move this to the `README.md`)